### PR TITLE
fix pg_rewind docs

### DIFF
--- a/doc/src/sgml/ref/pg_rewind.sgml
+++ b/doc/src/sgml/ref/pg_rewind.sgml
@@ -302,11 +302,19 @@ PostgreSQL documentation
        </para>
        <para>
         This option has no effect when <option>--no-sync</option> is used.
+       </para>
+      </listitem>
+     </varlistentry>
+
+     <varlistentry>
       <term><option>-e <replaceable class="parameter">path</replaceable></option></term>
       <term><option>--extension=<replaceable class="parameter">path</replaceable></option></term>
       <listitem>
        <para>
-        Load shared library that performs custom rewind for postgres extension. The <replaceable class="parameter">path</replaceable> may be full or relative to PKGLIBDIR. File extension is optional. Multiple extensions can be selected by multiple <option>-e</option> switches.
+        Load shared library that performs custom rewind for postgres extension.
+        The <replaceable class="parameter">path</replaceable> may be full or
+        relative to PKGLIBDIR. File extension is optional. Multiple extensions
+        can be selected by multiple <option>-e</option> switches.
        </para>
       </listitem>
      </varlistentry>


### PR DESCRIPTION
A previous commit, 73f1c62e1e70221d2b57e0c5ad1be4a1a80d3c53, added lines to the doc files which resulted in unclosed tags, which makes the docs build fail.

I think this is what the author meant to do.

I'm not sure if this is the right place to merge this commit.