### PR TITLE
Initialize isLocal if temp tables are available

### DIFF
--- a/src/backend/utils/cache/inval.c
+++ b/src/backend/utils/cache/inval.c
@@ -1474,6 +1474,12 @@ CacheInvalidateRelcacheByDbidRelid(Oid dbid, Oid relid)
 	msg.rc.id = SHAREDINVALRELCACHE_ID;
 	msg.rc.dbId = dbid;
 	msg.rc.relId = relid;
+
+/* Initialize isLocal if temp tables are available */
+#ifdef TEMP_TABLE_SCOPE_LOCAL
+	msg.isLocal = false;
+#endif
+
 	/* check AddCatcacheInvalidationMessage() for an explanation */
 	VALGRIND_MAKE_MEM_DEFINED(&msg, sizeof(msg));
 


### PR DESCRIPTION
If message has `isLocal` field and it is not initialized, it contains garbage value, which is usually evaluated to true, which is incorrect in general case, by default cache is not local.