### PR TITLE
fix regress test: orioledb toast values cannot have indirect pointers

### DIFF
--- a/src/test/regress/parallel_schedule_oriole
+++ b/src/test/regress/parallel_schedule_oriole
@@ -91,7 +91,7 @@ test: subscription
 # Another group of parallel tests
 # select_views depends on create_view
 # ----------
-test: select_views portals_p2 dependency guc bitmapops xmlmap functional_deps advisory_lock 
+test: select_views portals_p2 dependency guc bitmapops xmlmap functional_deps advisory_lock indirect_toast
 
 # ----------
 # Another group of parallel tests (JSON related)

--- a/src/test/regress/regress.c
+++ b/src/test/regress/regress.c
@@ -604,6 +604,10 @@ make_tuple_indirect(PG_FUNCTION_ARGS)
 		/* don't recursively indirect */
 		if (VARATT_IS_EXTERNAL_INDIRECT(attr))
 			continue;
+		
+		/* orioledb toast values cannot have indirect pointers */
+		if (VARATT_IS_EXTERNAL_ORIOLEDB(attr))
+			continue;
 
 		/* copy datum, so it still lives later */
 		if (VARATT_IS_EXTERNAL_ONDISK(attr) || VARATT_IS_EXTERNAL_ORIOLEDB(attr))


### PR DESCRIPTION
> Egor:
Правильно я понимаю что ориоль пока просто не хэндлит VARATT_IS_EXTERNAL_INDIRECT тип поинтера?

> Pavel:
Да, это так. И поскольку у Oriole свой формат тоста, то возможно для этого нужен будет отдельный вид (VARATT_IS_EXTERNAL_ORIOLEDB_INDIRECT)

> Egor:
В indirect_toast тесте устанавливается для тапла VARTAG_INDIRECT, который насколько я понимаю сам по себе поставиться для аттрибутов в таблицах ориоли никогда не может (всегда будет VARTAG_ORIOLEDB). Так что предлагаю в этой [функции](https://github.com/orioledb/postgres/blob/patches16/src/test/regress/regress.c#L605) в регресс тесте скипать аттрибуты с VARTAG_ORIOLEDB и не выставлять для них VARTAG_INDIRECT, так-как это прямое нарушение консистентности ориоль таплов

> Pavel:
Да, выставлять VARTAG_INDIRECT для Oriole туплов - нельзя

Closes https://github.com/orioledb/orioledb/issues/582