### PR TITLE
Revert "fix regress test: orioledb toast values cannot have indirect pointers"

### DIFF
--- a/src/test/regress/parallel_schedule_oriole
+++ b/src/test/regress/parallel_schedule_oriole
@@ -91,7 +91,8 @@ test: subscription
 # Another group of parallel tests
 # select_views depends on create_view
 # ----------
-test: select_views portals_p2 dependency guc bitmapops xmlmap functional_deps advisory_lock indirect_toast
+# indirect_toast should not be enabled for oriole as it breaks the engine constraints with its function make_tuple_indirect
+test: select_views portals_p2 dependency guc bitmapops xmlmap functional_deps advisory_lock 
 
 # ----------
 # Another group of parallel tests (JSON related)

--- a/src/test/regress/parallel_schedule_oriole
+++ b/src/test/regress/parallel_schedule_oriole
@@ -91,7 +91,7 @@ test: subscription
 # Another group of parallel tests
 # select_views depends on create_view
 # ----------
-test: select_views portals_p2 dependency guc bitmapops xmlmap functional_deps advisory_lock 
+test: select_views portals_p2 dependency guc bitmapops xmlmap functional_deps advisory_lock indirect_toast
 
 # ----------
 # Another group of parallel tests (JSON related)

--- a/src/test/regress/regress.c
+++ b/src/test/regress/regress.c
@@ -605,6 +605,10 @@ make_tuple_indirect(PG_FUNCTION_ARGS)
 		if (VARATT_IS_EXTERNAL_INDIRECT(attr))
 			continue;
 
+		/* orioledb toast values cannot have indirect pointers */
+		if (VARATT_IS_EXTERNAL_ORIOLEDB(attr))
+			continue;
+
 		/* copy datum, so it still lives later */
 		if (VARATT_IS_EXTERNAL_ONDISK(attr) || VARATT_IS_EXTERNAL_ORIOLEDB(attr))
 			attr = detoast_external_attr(attr);

--- a/src/test/regress/regress.c
+++ b/src/test/regress/regress.c
@@ -605,10 +605,6 @@ make_tuple_indirect(PG_FUNCTION_ARGS)
 		if (VARATT_IS_EXTERNAL_INDIRECT(attr))
 			continue;
 
-		/* orioledb toast values cannot have indirect pointers */
-		if (VARATT_IS_EXTERNAL_ORIOLEDB(attr))
-			continue;
-
 		/* copy datum, so it still lives later */
 		if (VARATT_IS_EXTERNAL_ONDISK(attr) || VARATT_IS_EXTERNAL_ORIOLEDB(attr))
 			attr = detoast_external_attr(attr);


### PR DESCRIPTION
This reverts commit 83f1e0a8b8e15e8c48231cf3c4c338ddb47cfda8.