### PR TITLE
Enable running subscription tests with oriole

### DIFF
--- a/patches/subscription_enable_oriole.diff
+++ b/patches/subscription_enable_oriole.diff
@@ -1,0 +1,19 @@
+diff --git a/src/test/perl/PostgreSQL/Test/Cluster.pm b/src/test/perl/PostgreSQL/Test/Cluster.pm
+index b95ba721f71..ea04f1c0b1b 100644
+--- a/src/test/perl/PostgreSQL/Test/Cluster.pm
++++ b/src/test/perl/PostgreSQL/Test/Cluster.pm
+@@ -1060,6 +1060,15 @@ sub start
+ 	}
+
+ 	$self->_update_pid(1);
++
++	if ((! -e $self->data_dir . '/standby.signal') && (! -e $self->data_dir . '/recovery.signal'))
++	{
++		$self->safe_psql(
++			'template1', qq{CREATE EXTENSION IF NOT EXISTS orioledb;});
++		$self->safe_psql(
++			'postgres', qq{CREATE EXTENSION IF NOT EXISTS orioledb;});
++	}
++
+ 	return 1;
+ }

--- a/src/test/subscription/Makefile
+++ b/src/test/subscription/Makefile
@@ -23,5 +23,27 @@ check:
 installcheck:
 	$(prove_installcheck)
 
+# Run OrioleDB-specific subscription tests
+# Tests to run are listed in oriole_tests.txt
+installcheck-oriole:
+	@if [ ! -f oriole_tests.txt ]; then \
+		echo "Error: oriole_tests.txt not found"; \
+		echo "Create oriole_tests.txt with a list of test files to run"; \
+		exit 1; \
+	fi
+	@if [ ! -f orioledb.conf ]; then \
+		echo "Error: orioledb.conf not found"; \
+		exit 1; \
+	fi
+	@ORIOLE_TESTS=$$(grep -v '^#' oriole_tests.txt | grep -v '^$$' | tr '\n' ' '); \
+	if [ -z "$$ORIOLE_TESTS" ]; then \
+		echo "No tests found in oriole_tests.txt"; \
+		exit 1; \
+	fi; \
+	$(MAKE) installcheck \
+		TEMP_CONFIG="$(CURDIR)/orioledb.conf" \
+		PG_TEST_INITDB_EXTRA_OPTS="--locale=C" \
+		PROVE_TESTS="$$ORIOLE_TESTS"
+
 clean distclean:
 	rm -rf tmp_check

--- a/src/test/subscription/oriole_tests.txt
+++ b/src/test/subscription/oriole_tests.txt
@@ -1,0 +1,12 @@
+# List of subscription tests to run with OrioleDB
+# Add test files here, one per line
+
+t/005_encoding.pl
+t/006_rewrite.pl
+t/007_ddl.pl
+t/008_diff_schema.pl
+t/010_truncate.pl
+t/011_generated.pl
+t/020_messages.pl
+t/024_add_drop_pub.pl
+t/026_stats.pl

--- a/src/test/subscription/orioledb.conf
+++ b/src/test/subscription/orioledb.conf
@@ -1,0 +1,2 @@
+default_table_access_method = 'orioledb'
+shared_preload_libraries = 'orioledb'


### PR DESCRIPTION
`oriole_tests.txt` contains only tests that currently pass with oriole