### PR TITLE
Patches16 release syscache in TryReuseIndex

### DIFF
--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13985,6 +13985,7 @@ TryReuseIndex(Oid oldId, IndexStmt *stmt)
 			}
 			accessMethodForm = (Form_pg_am) GETSTRUCT(tuple);
 			amRoutine = GetIndexAmRoutineWithTableAM(heapRel->rd_rel->relam, accessMethodForm->amhandler);
+			ReleaseSysCache(tuple);
 			table_close(heapRel, NoLock);
 			
 			if(amRoutine->amreuse) {

--- a/src/backend/commands/tablecmds.c
+++ b/src/backend/commands/tablecmds.c
@@ -13950,14 +13950,14 @@ TryReuseIndex(Oid oldId, IndexStmt *stmt)
 			Form_pg_am	accessMethodForm;
 			IndexAmRoutine *amRoutine;
 			char	   *accessMethodName;
-			Oid heapRelId = IndexGetRelation(oldId, false);
-			Relation heapRel = table_open(heapRelId, ShareLock);
-			
+			Oid			heapRelId = IndexGetRelation(oldId, false);
+			Relation	heapRel = table_open(heapRelId, ShareLock);
+
 			stmt->oldNumber = irel->rd_locator.relNumber;
 			stmt->oldCreateSubid = irel->rd_createSubid;
 			stmt->oldFirstRelfilelocatorSubid = irel->rd_firstRelfilelocatorSubid;
-			
-			
+
+
 			/*
 			 * look up the access method to call amreuse
 			 */
@@ -13966,8 +13966,9 @@ TryReuseIndex(Oid oldId, IndexStmt *stmt)
 			if (!HeapTupleIsValid(tuple))
 			{
 				/*
-				 * Hack to provide more-or-less-transparent updating of old RTREE
-				 * indexes to GiST: if RTREE is requested and not found, use GIST.
+				 * Hack to provide more-or-less-transparent updating of old
+				 * RTREE indexes to GiST: if RTREE is requested and not found,
+				 * use GIST.
 				 */
 				if (strcmp(accessMethodName, "rtree") == 0)
 				{
@@ -13987,9 +13988,10 @@ TryReuseIndex(Oid oldId, IndexStmt *stmt)
 			amRoutine = GetIndexAmRoutineWithTableAM(heapRel->rd_rel->relam, accessMethodForm->amhandler);
 			ReleaseSysCache(tuple);
 			table_close(heapRel, NoLock);
-			
-			if(amRoutine->amreuse) {
-				(*amRoutine->amreuse)(irel);
+
+			if (amRoutine->amreuse)
+			{
+				(*amRoutine->amreuse) (irel);
 			}
 		}
 		index_close(irel, NoLock);


### PR DESCRIPTION
`tuple` is not released after allocating it by `SearchSysCache1()`.

It was introduced by https://github.com/orioledb/postgres/commit/69f793718ce3b9e3d02f97d56ee903526370abc7