### PR TITLE
Add `CustomErrorCleanup` call in `pgarch.c`

### DIFF
--- a/src/backend/postmaster/pgarch.c
+++ b/src/backend/postmaster/pgarch.c
@@ -566,6 +566,7 @@ pgarch_archiveXlog(char *xlog)
 		 */
 		disable_all_timeouts(false);
 		LWLockReleaseAll();
+		CustomErrorCleanup();
 		ConditionVariableCancelSleep();
 		pgstat_report_wait_end();
 		ReleaseAuxProcessResources(false);

--- a/src/backend/postmaster/walsummarizer.c
+++ b/src/backend/postmaster/walsummarizer.c
@@ -286,6 +286,7 @@ WalSummarizerMain(char *startup_data, size_t startup_data_len)
 
 		/* Release resources we might have acquired. */
 		LWLockReleaseAll();
+		CustomErrorCleanup();
 		ConditionVariableCancelSleep();
 		pgstat_report_wait_end();
 		ReleaseAuxProcessResources(false);


### PR DESCRIPTION
Looks like it is missing from `parch_archiveXlog` and `WalSummarizerMain`.