### PR TITLE
Allow pre-initialized catalog cache in single-user mode; fix missing …

### DIFF
--- a/src/backend/utils/cache/relcache.c
+++ b/src/backend/utils/cache/relcache.c
@@ -132,7 +132,7 @@ typedef struct relidcacheent
 	Relation	reldesc;
 } RelIdCacheEnt;
 
-static HTAB *RelationIdCache;
+static HTAB *RelationIdCache = NULL;
 
 /*
  * This flag is false until we have prepared the critical relcache entries
@@ -4002,6 +4002,12 @@ RelationCacheInitialize(void)
 	 */
 	if (!CacheMemoryContext)
 		CreateCacheMemoryContext();
+	
+	/*
+	 * nothing to do if it's already done
+	 */
+	if (RelationIdCache)
+		return;
 
 	/*
 	 * create hashtable that indexes the relcache

--- a/src/backend/utils/cache/syscache.c
+++ b/src/backend/utils/cache/syscache.c
@@ -112,7 +112,15 @@ InitCatalogCache(void)
 {
 	int			cacheId;
 
-	Assert(!CacheInitialized);
+	/* 
+	 * In single user mode, recovery might set up 
+	 * catalog caches before InitPostgres is called. 
+	 */
+	Assert(!CacheInitialized || !IsUnderPostmaster);
+
+	/* nothing to do if it's already done */
+	if (CacheInitialized)
+		return;
 
 	SysCacheRelationOidSize = SysCacheSupportingRelOidSize = 0;
 


### PR DESCRIPTION
…o_unset_syscache_hooks call

Single-user mode may run recovery and then start a session in the same process. When OrioleDB is loaded, recovery initializes the catalog cache, which caused session startup to fail because it expected a non-initialized state.

Allow the catalog cache to be already initialized when starting a session in single-user mode after recovery.

Additionally, fix a missing o_unset_syscache_hooks call, which left OrioleDB syscache hooks installed across the recovery/session boundary and contributed to crashes and inconsistent backend state.

This ensures that backend-global state is properly handled when recovery and normal session execution happen within the same process.

downlink-> https://github.com/orioledb/orioledb/pull/735