### PR TITLE
Enable more regress tests for Oriole (PG 17)

### DIFF
--- a/src/test/regress/parallel_schedule_oriole
+++ b/src/test/regress/parallel_schedule_oriole
@@ -14,21 +14,21 @@ test: test_setup
 # ----------
 # The first group of parallel tests
 # ----------
-test: boolean char name varchar text int2 int4 int8 oid float4 float8 bit numeric txid uuid enum money pg_lsn regproc
+test: boolean char name varchar text int2 int4 int8 oid float4 float8 bit numeric txid uuid enum money rangetypes pg_lsn regproc
 
 # ----------
 # The second group of parallel tests
 # multirangetypes depends on rangetypes
 # multirangetypes shouldn't run concurrently with type_sanity
 # ----------
-test: md5 numerology lseg line path circle date time timetz timestamp timestamptz interval inet macaddr macaddr8
+test: md5 numerology point lseg line box path circle date time timetz timestamp timestamptz interval inet macaddr macaddr8 multirangetypes
 
 # ----------
 # Another group of parallel tests
 # geometry depends on point, lseg, line, box, path, polygon, circle
 # horology depends on date, time, timetz, timestamp, timestamptz, interval
 # ----------
-test: horology tstypes regex comments expressions unicode xid mvcc
+test: horology tstypes regex type_sanity misc_sanity comments expressions unicode xid mvcc database
 
 # ----------
 # Load huge amounts of data
@@ -42,29 +42,31 @@ test: copy copyselect copydml
 # More groups of parallel tests
 # Note: many of the tests in later groups depend on create_index
 # ----------
-test: create_function_c create_misc create_operator create_procedure create_type create_schema create_view
+test: create_function_c create_misc create_operator create_procedure create_table create_type create_schema
+test: create_view
 
 # ----------
 # Another group of parallel tests
 # ----------
-test: create_aggregate create_function_sql create_cast typed_table drop_if_exists
+test: create_aggregate create_function_sql create_cast typed_table drop_if_exists roleattributes hash_func errors infinite_recurse
 
 # ----------
 # sanity_check does a vacuum, affecting the sort order of SELECT *
 # results. So it should not run parallel to other tests.
 # ----------
+test: sanity_check
 
 # ----------
 # Another group of parallel tests
 # aggregates depends on create_aggregate
 # join depends on create_misc
 # ----------
-test: select_into select_implicit select_having random delete
+test: select_into select_implicit select_having random hash_index delete
 
 # ----------
 # Another group of parallel tests
 # ----------
-test: init_privs security_label collate object_address drop_operator password 
+test: gist init_privs security_label collate lock object_address drop_operator password
 
 # ----------
 # Additional BRIN tests
@@ -75,14 +77,19 @@ test: init_privs security_label collate object_address drop_operator password
 # psql depends on create_am
 # amutils depends on geometry, create_index_spgist, hash_index, brin
 # ----------
-test: alter_generic alter_operator misc async dbsize sysviews tsrf create_role
+test: alter_generic alter_operator misc async dbsize sysviews tsrf collate.utf8 create_role
 
 # collate.linux.utf8 and collate.icu.utf8 tests cannot be run in parallel with each other
+test: psql_crosstab collate.linux.utf8 collate.windows.win1252
 
 # ----------
 # Run these alone so they don't run out of parallel workers
 # select_parallel depends on create_misc
 # ----------
+
+# Run this alone, because concurrent DROP TABLE would make non-superuser
+# "ANALYZE;" fail with "relation with OID $n does not exist".
+test: maintain_every
 
 # no relation related tests can be put in this group
 test: subscription
@@ -91,12 +98,12 @@ test: subscription
 # Another group of parallel tests
 # select_views depends on create_view
 # ----------
-test: select_views portals_p2 dependency guc bitmapops xmlmap functional_deps advisory_lock 
+test: select_views portals_p2 dependency guc bitmapops tsdicts foreign_data xmlmap functional_deps advisory_lock
 
 # ----------
 # Another group of parallel tests (JSON related)
 # ----------
-test: json_encoding jsonpath jsonpath_encoding jsonb_jsonpath sqljson sqljson_queryfuncs sqljson_jsontable
+test: json json_encoding jsonpath jsonpath_encoding jsonb_jsonpath sqljson sqljson_queryfuncs sqljson_jsontable
 
 # ----------
 # Another group of parallel tests
@@ -104,7 +111,7 @@ test: json_encoding jsonpath jsonpath_encoding jsonb_jsonpath sqljson sqljson_qu
 # NB: temp.sql does a reconnect which transiently uses 2 connections,
 # so keep this parallel group to at most 19 tests
 # ----------
-test: plancache rangefuncs prepare sequence polymorphism largeobject xml
+test: plancache rangefuncs prepare truncate sequence polymorphism largeobject xml
 
 # ----------
 # Another group of parallel tests
@@ -112,12 +119,12 @@ test: plancache rangefuncs prepare sequence polymorphism largeobject xml
 # The stats test resets stats, so nothing else needing stats access can be in
 # this group.
 # ----------
-test: hash_part predicate
+test: hash_part partition_aggregate partition_info predicate
 
 # event_trigger depends on create_am and cannot run concurrently with
 # any test that runs DDL
 # oidjoins is read-only, though, and should run late for best coverage
-test: oidjoins 
+test: oidjoins
 
 # event_trigger_login cannot run concurrently with any other tests because
 # on-login event handling could catch connection of a concurrent test.


### PR DESCRIPTION
Enabled more regress tests for Oriole in `src/test/regress/parallel_schedule_oriole`