### PR TITLE
Support replication origin advance for xid-less commits

### DIFF
--- a/src/backend/access/transam/xact.c
+++ b/src/backend/access/transam/xact.c
@@ -326,6 +326,7 @@ typedef struct SubXactCallbackItem
 static SubXactCallbackItem *SubXact_callbacks = NULL;
 
 xact_redo_hook_type xact_redo_hook = NULL;
+get_xidless_commit_lsn_hook_type get_xidless_commit_lsn_hook = NULL;
 
 /* local function prototypes */
 static void AssignTransactionId(TransactionState s);
@@ -1345,6 +1346,8 @@ RecordTransactionCommit(void)
 	 */
 	if (!markXidCommitted)
 	{
+		bool		replorigin;
+
 		/*
 		 * We expect that every RelationDropStorage is followed by a catalog
 		 * update, and hence XID assignment, so we shouldn't get here with any
@@ -1375,6 +1378,23 @@ RecordTransactionCommit(void)
 			LogStandbyInvalidations(nmsgs, invalMessages,
 									RelcacheInitFileInval);
 			wrote_xlog = true;	/* not strictly necessary */
+		}
+
+		replorigin = (replorigin_session_origin != InvalidRepOriginId &&
+					  replorigin_session_origin != DoNotReplicateId);
+
+		/*
+		 * Some storage engines can reach commit without a top-level heap XID
+		 * while still having a durable local commit anchor in PG WAL.  Allow
+		 * such engines to surface that LSN here so that replication-origin
+		 * state can still be advanced for xid-less commits.
+		 */
+		if (replorigin && get_xidless_commit_lsn_hook)
+		{
+			XLogRecPtr	local_commit = get_xidless_commit_lsn_hook(&wrote_xlog);
+
+			if (XLogRecPtrIsValid(local_commit))
+				replorigin_session_advance(replorigin_session_origin_lsn, Max(local_commit, XactLastRecEnd));
 		}
 
 		/*

--- a/src/include/access/xact.h
+++ b/src/include/access/xact.h
@@ -148,6 +148,19 @@ typedef enum
 typedef void (*SubXactCallback) (SubXactEvent event, SubTransactionId mySubid,
 								 SubTransactionId parentSubid, void *arg);
 
+/*
+ * Hook for extensions that can produce a durable local commit LSN for a
+ * top-level transaction without a heap XID.
+ *
+ * The hook is consulted from the xid-less path of RecordTransactionCommit().
+ * It should return a valid WAL LSN representing the extension's durable
+ * local commit anchor for the current transaction, or InvalidXLogRecPtr if
+ * no such anchor exists.
+ */
+typedef XLogRecPtr (*get_xidless_commit_lsn_hook_type) (bool *);
+extern PGDLLIMPORT get_xidless_commit_lsn_hook_type
+	get_xidless_commit_lsn_hook;
+
 /* Data structure for Save/RestoreTransactionCharacteristics */
 typedef struct SavedTransactionCharacteristics
 {

--- a/src/test/subscription/oriole_tests.txt
+++ b/src/test/subscription/oriole_tests.txt
@@ -15,5 +15,6 @@ t/012_collation.pl
 t/014_binary.pl
 t/020_messages.pl
 t/024_add_drop_pub.pl
+t/025_rep_changes_for_schema.pl
 t/026_stats.pl
 t/032_subscribe_use_index.pl


### PR DESCRIPTION
# Summary
This patch adds a transaction-level integration point to PostgreSQL commit machinery to support correct replication origin advancement for top-level transactions that reach commit without a heap XID but still have a durable local commit LSN.

The immediate motivation is fixing logical replication failures observed with storage engines that use a non-heap-XID commit model, such as OrioleDB.

# Problem
PostgreSQL currently assumes the following model:
- if a transaction has a top-level heap xid, its durable commit point is known through the regular commit WAL path
- if a transaction has no top-level heap xid, it is effectively treated as outside the ordinary commit/origin path

That assumption is too narrow for storage engines that can:
- commit without assigning a top-level heap xid
- still produce a real durable commit effect
- still have a valid local commit LSN in PostgreSQL WAL space

OrioleDB is one such case.

As a result, a logical replication apply worker can successfully apply changes and reach commit, but if the transaction has no top-level heap xid, PostgreSQL does not treat it as a participant in normal replication-origin advancement.

This breaks restart/replay correctness for subscriber-side logical apply.

# Root Cause
`RecordTransactionCommit()` currently ties replication-origin advancement to the ordinary heap-XID commit path.

Conceptually:
- `markXidCommitted == true`
    - regular commit WAL path exists
    - commit LSN is known
    - replication origin is advanced normally
- `markXidCommitted == false`
    - no regular commit record is produced
    - no generic way exists for PostgreSQL to ask whether the transaction still has a durable local commit point
    - replication origin is not advanced through the same commit/origin protocol

This means PostgreSQL currently has no general abstraction for:
- xid-less top-level transaction
- with durable commit effect
- with valid local commit LSN
- requiring correct replication-origin handling

# Solution
Introduce a new transaction-level hook: `get_xidless_commit_lsn_hook`.

Its contract is narrow:
- it is consulted only from `RecordTransactionCommit()`
- only for top-level transactions that reach commit without a heap xid
- if the extension can provide a durable local commit LSN for the current transaction, it returns that LSN

This lets PostgreSQL remain the owner of commit/origin policy, while allowing a storage engine to provide the missing durable anchor.