### PR TITLE
Add more regress tests

### DIFF
--- a/patches/limit.patch
+++ b/patches/limit.patch
@@ -1,0 +1,49 @@
+diff --git a/src/test/regress/sql/limit.sql b/src/test/regress/sql/limit.sql
+index 603910fe6d..0cfef4c77b 100644
+--- a/src/test/regress/sql/limit.sql
++++ b/src/test/regress/sql/limit.sql
+@@ -39,7 +39,7 @@ select * from int8_tbl offset (case when random() < 0.5 then null::bigint end);
+ -- Test assorted cases involving backwards fetch from a LIMIT plan node
+ begin;
+ 
+-declare c1 cursor for select * from int8_tbl limit 10;
++declare c1 scroll cursor for select * from int8_tbl limit 10;
+ fetch all in c1;
+ fetch 1 in c1;
+ fetch backward 1 in c1;
+@@ -47,7 +47,7 @@ fetch backward all in c1;
+ fetch backward 1 in c1;
+ fetch all in c1;
+ 
+-declare c2 cursor for select * from int8_tbl limit 3;
++declare c2 scroll cursor for select * from int8_tbl limit 3;
+ fetch all in c2;
+ fetch 1 in c2;
+ fetch backward 1 in c2;
+@@ -55,7 +55,7 @@ fetch backward all in c2;
+ fetch backward 1 in c2;
+ fetch all in c2;
+ 
+-declare c3 cursor for select * from int8_tbl offset 3;
++declare c3 scroll cursor for select * from int8_tbl offset 3;
+ fetch all in c3;
+ fetch 1 in c3;
+ fetch backward 1 in c3;
+@@ -63,7 +63,7 @@ fetch backward all in c3;
+ fetch backward 1 in c3;
+ fetch all in c3;
+ 
+-declare c4 cursor for select * from int8_tbl offset 10;
++declare c4 scroll cursor for select * from int8_tbl offset 10;
+ fetch all in c4;
+ fetch 1 in c4;
+ fetch backward 1 in c4;
+@@ -71,7 +71,7 @@ fetch backward all in c4;
+ fetch backward 1 in c4;
+ fetch all in c4;
+ 
+-declare c5 cursor for select * from int8_tbl order by q1 fetch first 2 rows with ties;
++declare c5 scroll cursor for select * from int8_tbl order by q1 fetch first 2 rows with ties;
+ fetch all in c5;
+ fetch 1 in c5;
+ fetch backward 1 in c5;

--- a/src/test/regress/parallel_schedule_oriole
+++ b/src/test/regress/parallel_schedule_oriole
@@ -28,7 +28,7 @@ test: strings md5 numerology point lseg line box path polygon circle date time t
 # geometry depends on point, lseg, line, box, path, polygon, circle
 # horology depends on date, time, timetz, timestamp, timestamptz, interval
 # ----------
-test: geometry horology tstypes regex type_sanity misc_sanity comments expressions unicode xid mvcc database
+test: geometry horology tstypes regex type_sanity opr_sanity misc_sanity comments expressions unicode xid mvcc database
 
 # ----------
 # Load huge amounts of data
@@ -61,26 +61,27 @@ test: sanity_check
 # aggregates depends on create_aggregate
 # join depends on create_misc
 # ----------
-test: select_into select_distinct select_implicit select_having subselect case aggregates random arrays btree_index hash_index update delete
+test: select_into select_distinct select_implicit select_having subselect union case aggregates random arrays btree_index hash_index update delete
 
 # ----------
 # Another group of parallel tests
 # ----------
-test: gin gist spgist privileges init_privs security_label collate lock object_address groupingsets drop_operator password generated
+test: gin gist spgist privileges init_privs security_label collate lock object_address groupingsets drop_operator password identity generated join_hash
 
 # ----------
 # Additional BRIN tests
 # ----------
+test: brin_bloom brin_multi
 
 # ----------
 # Another group of parallel tests
 # psql depends on create_am
 # amutils depends on geometry, create_index_spgist, hash_index, brin
 # ----------
-test: create_table_like alter_generic alter_operator misc async dbsize merge misc_functions sysviews tsrf collate.utf8 incremental_sort create_role
+test: create_table_like alter_generic alter_operator misc async dbsize merge misc_functions sysviews tsrf collate.utf8 collate.icu.utf8 incremental_sort create_role
 
 # collate.linux.utf8 and collate.icu.utf8 tests cannot be run in parallel with each other
-test: rules psql psql_crosstab collate.linux.utf8 collate.windows.win1252
+test: rules psql psql_crosstab stats_ext collate.linux.utf8 collate.windows.win1252
 
 # ----------
 # Run these alone so they don't run out of parallel workers
@@ -112,7 +113,7 @@ test: json jsonb json_encoding jsonpath jsonpath_encoding jsonb_jsonpath sqljson
 # NB: temp.sql does a reconnect which transiently uses 2 connections,
 # so keep this parallel group to at most 19 tests
 # ----------
-test: plancache copy2 domain rangefuncs prepare conversion truncate alter_table sequence polymorphism rowtypes returning largeobject with xml
+test: plancache limit copy2 domain rangefuncs prepare conversion truncate alter_table sequence polymorphism rowtypes returning largeobject with xml
 
 # ----------
 # Another group of parallel tests
@@ -120,7 +121,7 @@ test: plancache copy2 domain rangefuncs prepare conversion truncate alter_table 
 # The stats test resets stats, so nothing else needing stats access can be in
 # this group.
 # ----------
-test: partition_prune hash_part partition_aggregate partition_info explain memoize predicate
+test: partition_prune reloptions hash_part partition_aggregate partition_info explain memoize predicate
 
 # event_trigger depends on create_am and cannot run concurrently with
 # any test that runs DDL


### PR DESCRIPTION
## Summary

Enable additional PostgreSQL regression tests to run with OrioleDB storage engine.

### Tests enabled
- `brin_bloom` — fixes orioledb/orioledb#769
- `brin_multi` — fixes orioledb/orioledb#770
- `reloptions` — fixes orioledb/orioledb#779
- `opr_sanity` — fixes orioledb/orioledb#761
- `union` — fixes orioledb/orioledb#764
- `join_hash` — fixes orioledb/orioledb#768
- `collate.icu.utf8` — fixes orioledb/orioledb#772
- `limit` — fixes orioledb/orioledb#778
- `stats_ext`
- `identity` -- fixes orioledb/orioledb#766

Corresponding PRs to the orioledb repo: https://github.com/orioledb/orioledb/pull/814 and https://github.com/orioledb/orioledb/pull/816
