### PR TITLE
Add recovery target reached hook with stop-boundary metadata PG16

### DIFF
--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -1808,6 +1808,7 @@ PerformWalRecovery(void)
 			{
 				RecoveryTargetReachedInfo recoveryTargetReachedInfo;
 
+				recoveryTargetReachedInfo.recoveryStopAfter = recoveryStopAfter;
 				recoveryTargetReachedInfo.recordPtr = xlogreader->ReadRecPtr;
 				recoveryTargetReachedInfo.recordEndPtr = xlogreader->EndRecPtr;
 

--- a/src/backend/access/transam/xlogrecovery.c
+++ b/src/backend/access/transam/xlogrecovery.c
@@ -1798,6 +1798,22 @@ PerformWalRecovery(void)
 			 * Resource Managers may choose to do permanent corrective actions
 			 * at end of recovery.
 			 */
+
+			/*
+			 * Pass the exact stop-boundary metadata to extensions so they can
+			 * synchronize custom replay state against the record that caused
+			 * recovery to stop.
+			 */
+			if (RecoveryTargetReachedHook != NULL)
+			{
+				RecoveryTargetReachedInfo recoveryTargetReachedInfo;
+
+				recoveryTargetReachedInfo.recordPtr = xlogreader->ReadRecPtr;
+				recoveryTargetReachedInfo.recordEndPtr = xlogreader->EndRecPtr;
+
+				RecoveryTargetReachedHook(&recoveryTargetReachedInfo);
+			}
+
 			switch (recoveryTargetAction)
 			{
 				case RECOVERY_TARGET_ACTION_SHUTDOWN:
@@ -4538,6 +4554,8 @@ GetXLogReplayRecPtr(TimeLineID *replayTLI)
 GetReplayXlogPtrHookType GetReplayXlogPtrHook = NULL;
 
 RecoveryStopsBeforeHookType RecoveryStopsBeforeHook = NULL;
+
+RecoveryTargetReachedHookType RecoveryTargetReachedHook = NULL;
 
 /*
  * Get effective latest redo apply position.

--- a/src/include/access/xlogrecovery.h
+++ b/src/include/access/xlogrecovery.h
@@ -54,6 +54,25 @@ typedef bool (*RecoveryStopsBeforeHookType) (XLogReaderState *record,
 											 TransactionId *recordXid,
 											 TimestampTz *recordXtime);
 
+/*
+ * Metadata describing the recovery stop boundary that PostgreSQL has just
+ * reached. This is passed to extensions so they can synchronize or finalize
+ * their own replay state before recovery_target_action is applied.
+ */
+typedef struct RecoveryTargetReachedInfo
+{
+	XLogRecPtr	recordPtr;			/* ReadRecPtr of the record at the stop boundary */
+	XLogRecPtr	recordEndPtr;		/* EndRecPtr of the record at the stop boundary */
+} RecoveryTargetReachedInfo;
+
+/*
+ * Hook for extensions to synchronize or finalize custom replay state after
+ * PostgreSQL has reached a recovery target, but before recovery_target_action
+ * is applied. The hook receives explicit metadata describing the stop
+ * boundary that was reached.
+ */
+typedef void (*RecoveryTargetReachedHookType) (const RecoveryTargetReachedInfo *info);
+
 /* User-settable GUC parameters */
 extern PGDLLIMPORT bool recoveryTargetInclusive;
 extern PGDLLIMPORT int recoveryTargetAction;
@@ -86,10 +105,17 @@ extern PGDLLIMPORT bool StandbyMode;
 extern PGDLLIMPORT GetReplayXlogPtrHookType GetReplayXlogPtrHook;
 
 /*
- * Hook for extensions to be able to decides to stop applying the WAL files
+ * Hook for extensions to be able to decide whether to stop applying WAL
  * based on custom WAL records.
  */
 extern PGDLLIMPORT RecoveryStopsBeforeHookType RecoveryStopsBeforeHook;
+
+/*
+ * Hook for extensions to synchronize or finalize custom replay state after
+ * PostgreSQL has reached a recovery target, but before recovery_target_action
+ * is applied.
+ */
+extern PGDLLIMPORT RecoveryTargetReachedHookType RecoveryTargetReachedHook;
 
 extern Size XLogRecoveryShmemSize(void);
 extern void XLogRecoveryShmemInit(void);

--- a/src/include/access/xlogrecovery.h
+++ b/src/include/access/xlogrecovery.h
@@ -61,6 +61,7 @@ typedef bool (*RecoveryStopsBeforeHookType) (XLogReaderState *record,
  */
 typedef struct RecoveryTargetReachedInfo
 {
+	bool		recoveryStopAfter;
 	XLogRecPtr	recordPtr;			/* ReadRecPtr of the record at the stop boundary */
 	XLogRecPtr	recordEndPtr;		/* EndRecPtr of the record at the stop boundary */
 } RecoveryTargetReachedInfo;


### PR DESCRIPTION
## Summary

Add a new `RecoveryTargetReachedHook` that is invoked after PostgreSQL has determined that a recovery target has been reached, but before `recovery_target_action` is applied.

The hook receives explicit stop-boundary metadata via `RecoveryTargetReachedInfo`, including:
- target type
- stop semantics (`before` / `after`)
- stop metadata (`xid`, `time`, `LSN`, `name`)
- `ReadRecPtr` / `EndRecPtr` for the record at the stop boundary

## Problem

PostgreSQL can reach a recovery target before an extension with custom replay/finalization logic has fully synchronized its own visible state to that same stop boundary.

In such cases, PostgreSQL already considers the target reached, but the extension-visible state may still lag behind the actual recovery stop point. This makes it difficult for extensions to guarantee correct target-point visibility semantics using only generic replay-progress information.

## Motivation

Extensions with custom replay/finalization logic may need to synchronize their internal state against the actual recovery stop boundary before PostgreSQL exposes the target-reached state.

A generic replay-progress pointer is not always sufficient for this, especially for target types where extension-visible state must match the precise stop boundary semantics.

## Changes

- add `RecoveryTargetReachedInfo` to carry recovery stop-boundary metadata
- add `RecoveryTargetReachedHookType`
- add `RecoveryTargetReachedHook`
- invoke the hook in `PerformWalRecovery()` after `reachedRecoveryTarget`   and before `recovery_target_action` is applied

## Result

This gives extensions an explicit integration point for target-boundary synchronization/finalization without changing normal replay flow.

## Issue

Closes: https://github.com/orioledb/orioledb/issues/820
