### PR TITLE
Free temporary rowid Datums after index and trigger use

### DIFF
--- a/src/backend/commands/trigger.c
+++ b/src/backend/commands/trigger.c
@@ -6672,6 +6672,16 @@ AfterTriggerSaveEvent(EState *estate, ResultRelInfo *relinfo,
 	}
 
 	/*
+	 * slot_getsysattr(RowIdAttributeNumber) returns an owning palloc'd copy.
+	 * afterTriggerAddEvent() copies rowids into its event chunk, so these
+	 * temporary copies don't need to live until PortalContext reset.
+	 */
+	if (rowId1)
+		pfree(rowId1);
+	if (rowId2 && rowId2 != rowId1)
+		pfree(rowId2);
+
+	/*
 	 * Finally, spool any foreign tuple(s).  The tuplestore squashes them to
 	 * minimal tuples, so this loses any system columns.  The executor lost
 	 * those columns before us, for an unrelated reason, so this is fine.

--- a/src/backend/executor/execIndexing.c
+++ b/src/backend/executor/execIndexing.c
@@ -496,6 +496,10 @@ ExecInsertIndexTuples(ResultRelInfo *resultRelInfo,
 		}
 	}
 
+	if (table_get_row_ref_type(heapRelation) == ROW_REF_ROWID &&
+		DatumGetPointer(tupleidDatum) != NULL)
+		pfree(DatumGetPointer(tupleidDatum));
+
 	return result;
 }
 
@@ -664,6 +668,7 @@ ExecUpdateIndexTuples(ResultRelInfo *resultRelInfo,
 			if (table_get_row_ref_type(resultRelInfo->ri_RelationDesc) == ROW_REF_ROWID)
 			{
 				bool	isnull;
+
 				oldTupleidDatum = slot_getsysattr(oldSlot, RowIdAttributeNumber, &isnull);
 				Assert(!isnull);
 			}
@@ -717,6 +722,10 @@ ExecUpdateIndexTuples(ResultRelInfo *resultRelInfo,
 							 checkUnique,	/* type of uniqueness check to do */
 							 indexUnchanged,	/* UPDATE without logical change? */
 							 indexInfo);	/* index AM may need this */
+
+			if (table_get_row_ref_type(heapRelation) == ROW_REF_ROWID &&
+				DatumGetPointer(oldTupleidDatum) != NULL)
+				pfree(DatumGetPointer(oldTupleidDatum));
 
 		}
 		else
@@ -790,6 +799,10 @@ ExecUpdateIndexTuples(ResultRelInfo *resultRelInfo,
 				*specConflict = true;
 		}
 	}
+
+	if (table_get_row_ref_type(heapRelation) == ROW_REF_ROWID &&
+		DatumGetPointer(tupleidDatum) != NULL)
+		pfree(DatumGetPointer(tupleidDatum));
 
 	return result;
 }
@@ -898,6 +911,10 @@ ExecDeleteIndexTuples(ResultRelInfo *resultRelInfo, TupleTableSlot *slot,
 					 heapRelation,	/* heap relation */
 					 indexInfo);	/* index AM may need this */
 	}
+
+	if (table_get_row_ref_type(heapRelation) == ROW_REF_ROWID &&
+		DatumGetPointer(tupleid) != NULL)
+		pfree(DatumGetPointer(tupleid));
 }
 
 /* ----------------------------------------------------------------
@@ -1215,11 +1232,16 @@ retry:
 			{
 				bool	isnull;
 				Datum existing_rowid;
+				bool	is_self;
 
 				existing_rowid = slot_getsysattr(existing_slot, RowIdAttributeNumber, &isnull);
 				Assert(!isnull);
 
-				if (table_row_ref_equals(heap, tupleidDatum, existing_rowid))
+				is_self = table_row_ref_equals(heap, tupleidDatum, existing_rowid);
+				if (DatumGetPointer(existing_rowid) != NULL)
+					pfree(DatumGetPointer(existing_rowid));
+
+				if (is_self)
 				{
 					if (found_self)		/* should not happen */
 						elog(ERROR, "found self tuple multiple times in index \"%s\"",

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2457,6 +2457,9 @@ ExecOnConflictUpdate(ModifyTableContext *context,
 
 	if (!ExecQual(onConflictSetWhere, econtext))
 	{
+		if (table_get_row_ref_type(resultRelInfo->ri_RelationDesc) == ROW_REF_ROWID &&
+			DatumGetPointer(tupleid) != NULL)
+			pfree(DatumGetPointer(tupleid));
 		ExecClearTuple(existing);	/* see return below */
 		InstrCountFiltered1(&mtstate->ps, 1);
 		return true;			/* done with the tuple */
@@ -2502,6 +2505,10 @@ ExecOnConflictUpdate(ModifyTableContext *context,
 							resultRelInfo->ri_onConflict->oc_ProjSlot,
 							existing,
 							canSetTag, true);
+
+	if (table_get_row_ref_type(resultRelInfo->ri_RelationDesc) == ROW_REF_ROWID &&
+		DatumGetPointer(tupleid) != NULL)
+		pfree(DatumGetPointer(tupleid));
 
 	/*
 	 * Clear out existing tuple, as there might not be another conflict among


### PR DESCRIPTION
## Summary

This patch reduces `PortalContext` memory growth for `ROW_REF_ROWID` table AMs during long statements such as large `COPY FROM`.

For `ROW_REF_ROWID` relations, `slot_getsysattr(RowIdAttributeNumber)` returns a caller-owned `palloc` copy of the rowid. The index insertion/update/delete paths and after-trigger event queue either consume the rowid immediately or copy it into their own long-lived storage. The temporary caller-owned copy therefore does not need to live until `PortalContext` reset.

This patch explicitly frees those temporary rowid Datums after index/trigger use.

## Reason

Large TPC-C `COPY FROM` loads with OrioleDB accumulated per-row temporary rowid copies in `PortalContext`. This produced unnecessary private backend memory growth during long COPY statements.

After this change, `PortalContext` stays small during the same load path.

## Notes

The change relies on the `ROW_REF_ROWID` ownership contract: `slot_getsysattr(RowIdAttributeNumber)` must return a caller-owned `palloc` Datum. This is documented near the helper that decides whether the tuple id should be freed.

## Testing

Validated with Stroppy TPC-C load on OrioleDB:

- `scale_factor=1000`
- `load_workers=16`
- FK constraints moved after load to isolate COPY memory behavior
- `PortalContext` stayed small
- `AfterTriggerEvents` did not accumulate during COPY
- load, add constraints, and population validation completed successfully