### PR TITLE
Fix set_plain_rel_pathlist path [patches17]

### DIFF
--- a/src/backend/optimizer/path/allpaths.c
+++ b/src/backend/optimizer/path/allpaths.c
@@ -773,10 +773,11 @@ set_plain_rel_pathlist(PlannerInfo *root, RelOptInfo *rel, RangeTblEntry *rte)
 	 */
 	required_outer = rel->lateral_relids;
 
-	if (!set_plain_rel_pathlist_hook ||
-		set_plain_rel_pathlist_hook(root, rel, rte))
-		/* Consider sequential scan */
-		add_path(rel, create_seqscan_path(root, rel, required_outer, 0));
+	if (set_plain_rel_pathlist_hook)
+		set_plain_rel_pathlist_hook(root, rel, rte);
+
+	/* Consider sequential scan */
+	add_path(rel, create_seqscan_path(root, rel, required_outer, 0));
 
 	/* If appropriate, consider parallel sequential scan */
 	if (rel->consider_parallel && required_outer == NULL)

--- a/src/include/optimizer/paths.h
+++ b/src/include/optimizer/paths.h
@@ -32,7 +32,7 @@ typedef void (*set_rel_pathlist_hook_type) (PlannerInfo *root,
 											Index rti,
 											RangeTblEntry *rte);
 extern PGDLLIMPORT set_rel_pathlist_hook_type set_rel_pathlist_hook;
-typedef bool (*set_plain_rel_pathlist_hook_type)(PlannerInfo *root,
+typedef void (*set_plain_rel_pathlist_hook_type)(PlannerInfo *root,
 												 RelOptInfo *rel,
 												 RangeTblEntry *rte);
 extern PGDLLIMPORT set_plain_rel_pathlist_hook_type set_plain_rel_pathlist_hook;


### PR DESCRIPTION
Previously addition of SeqScan to the pathlist depended on the return value of the set_plain_rel_pathlist hook. This would result in SeqScan not being considered in certain cases.

Related back and forward ports are as follows:
[patches18](https://github.com/orioledb/postgres/tree/nickb/fix_seqscan_planner_path_creation_patches18)
[patches16](https://github.com/orioledb/postgres/tree/nickb/fix_seqscan_planner_path_creation_patches16)