### PR TITLE
pg_checksums: skip orioledb_data directories

### DIFF
--- a/src/bin/pg_checksums/pg_checksums.c
+++ b/src/bin/pg_checksums/pg_checksums.c
@@ -304,6 +304,11 @@ scan_directory(const char *basedir, const char *subdir, bool sizeonly)
 	struct dirent *de;
 
 	snprintf(path, sizeof(path), "%s/%s", basedir, subdir);
+
+	/* OrioleDB data isn't pg_checksums' format; see orioledb_checksums. */
+	if (strcmp(subdir, "orioledb_data") == 0)
+		return 0;
+
 	dir = opendir(path);
 	if (!dir)
 		pg_fatal("could not open directory \"%s\": %m", path);


### PR DESCRIPTION
Exclude orioledb_data from pg_checksums walk, otherwise "Invalid segment number 0" error happens
