### PR TITLE
Add amnblocks index AM method

### DIFF
--- a/src/backend/storage/buffer/bufmgr.c
+++ b/src/backend/storage/buffer/bufmgr.c
@@ -37,6 +37,7 @@
 #include <sys/file.h>
 #include <unistd.h>
 
+#include "access/amapi.h"
 #include "access/tableam.h"
 #include "access/xloginsert.h"
 #include "access/xlogutils.h"
@@ -4021,6 +4022,17 @@ RelationGetNumberOfBlocksInFork(Relation relation, ForkNumber forkNum)
 	}
 	else if (RELKIND_HAS_STORAGE(relation->rd_rel->relkind))
 	{
+		if (relation->rd_rel->relkind == RELKIND_INDEX &&
+			relation->rd_indam != NULL &&
+			relation->rd_indam->amnblocks != NULL)
+		{
+			BlockNumber nblocks;
+
+			nblocks = relation->rd_indam->amnblocks(relation, forkNum);
+			if (BlockNumberIsValid(nblocks))
+				return nblocks;
+		}
+
 		return smgrnblocks(RelationGetSmgr(relation), forkNum);
 	}
 	else

--- a/src/include/access/amapi.h
+++ b/src/include/access/amapi.h
@@ -241,6 +241,10 @@ typedef void (*aminitparallelscan_function) (void *target);
 /* (re)start parallel index scan */
 typedef void (*amparallelrescan_function) (IndexScanDesc scan);
 
+/* report number of index blocks */
+typedef BlockNumber (*amnblocks_function) (Relation indexRelation,
+										   ForkNumber forkNum);
+
 /*
  * API struct for an index AM.  Note this must be stored in a single palloc'd
  * chunk of memory.
@@ -333,6 +337,9 @@ typedef struct IndexAmRoutine
 	amestimateparallelscan_function amestimateparallelscan; /* can be NULL */
 	aminitparallelscan_function aminitparallelscan; /* can be NULL */
 	amparallelrescan_function amparallelrescan; /* can be NULL */
+
+	/* report number of index blocks, can be NULL */
+	amnblocks_function amnblocks;	/* can be NULL */
 } IndexAmRoutine;
 
 


### PR DESCRIPTION
RelationGetNumberOfBlocksInFork called smgrnblocks, which returned 0 for Orioledb indexes. The planner read relpages from this, so index scan/bitmap index scan or seq scan were preferred to IOS

amnblocks lets the AM override the block count before the smgr fallback.