### PR TITLE
Re-find the proclock after waiting instead of trusting a stale pointer

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1266,18 +1266,68 @@ LockAcquireExtended(const LOCKTAG *locktag,
 			DeadLockReport();
 			/* DeadLockReport() will not return */
 		}
-		else if (!(proclock->holdMask & LOCKBIT_ON(lockmode)))
+		else
 		{
+			PROCLOCKTAG proclocktag;
+			bool		granted;
+
 			/*
-			 * We've been removed from the queue without obtaining a lock.
-			 * That's OK, we're going to return LOCKACQUIRE_NOT_AVAIL.
+			 * Whether the lock was granted has to be re-read from the lock
+			 * table, not from the proclock pointer we captured before going
+			 * to sleep.  A wake-up driven by RemoveFromWaitQueue() -- which
+			 * is how orioledb's oxid_notify_all() releases waiters, reporting
+			 * PROC_WAIT_STATUS_OK afterwards -- runs CleanUpLock(), and that
+			 * frees the proclock whenever it holds nothing else, which is
+			 * always so for a pure waiter.  Reading holdMask through the
+			 * freed element yields whatever the next owner of that dynahash
+			 * slot has put there; a stray set bit makes us believe in a grant
+			 * that never happened, and the release that follows underflows
+			 * the request counts and removes a proclock that is no longer in
+			 * the table ("proclock table corrupted").
+			 *
+			 * The lock itself can be gone too -- CleanUpLock() drops it once
+			 * nRequested reaches zero -- so start from the locktag.
 			 */
-			AbortStrongLockAcquire();
-			if (locallock->nLocks == 0)
-				RemoveLocalLock(locallock);
-			if (locallockp)
-				*locallockp = NULL;
-			return LOCKACQUIRE_NOT_AVAIL;
+			LWLockAcquire(partitionLock, LW_SHARED);
+			lock = (LOCK *) hash_search_with_hash_value(LockMethodLockHash,
+														locktag,
+														hashcode,
+														HASH_FIND,
+														NULL);
+			proclock = NULL;
+			if (lock != NULL)
+			{
+				proclocktag.myLock = lock;
+				proclocktag.myProc = MyProc;
+				proclock = (PROCLOCK *)
+					hash_search_with_hash_value(LockMethodProcLockHash,
+												&proclocktag,
+												ProcLockHashCode(&proclocktag,
+																 hashcode),
+												HASH_FIND,
+												NULL);
+			}
+			granted = (proclock != NULL &&
+					   (proclock->holdMask & LOCKBIT_ON(lockmode)) != 0);
+			LWLockRelease(partitionLock);
+
+			if (!granted)
+			{
+				/*
+				 * We've been removed from the queue without obtaining a lock.
+				 * That's OK, we're going to return LOCKACQUIRE_NOT_AVAIL.
+				 */
+				AbortStrongLockAcquire();
+				if (locallock->nLocks == 0)
+					RemoveLocalLock(locallock);
+				if (locallockp)
+					*locallockp = NULL;
+				return LOCKACQUIRE_NOT_AVAIL;
+			}
+
+			/* Keep the local lock's cached pointers in step. */
+			locallock->lock = lock;
+			locallock->proclock = proclock;
 		}
 	}
 	else


### PR DESCRIPTION
Fixes **ORI-247** — `PANIC: proclock table corrupted`, reported by Antithesis
on

```sql
insert into txn0 as t (id, sk, val) values ($1,$2,$3)
  on conflict (id) do update set val = CONCAT(t.val, ',', $4) where t.id = $5
```

and described there as "now happening consistently".

## The defect

After `WaitOnLock()` returns `PROC_WAIT_STATUS_OK`, `LockAcquireExtended()`
decides whether the lock was granted by reading `holdMask` **out of the
proclock pointer it captured before going to sleep**. That pointer is not
guaranteed to still be ours.

A waiter can be released by `RemoveFromWaitQueue()` rather than by the normal
grant path — orioledb's `oxid_notify_all()` does exactly that and then reports
`PROC_WAIT_STATUS_OK`, which is what the `LOCKACQUIRE_NOT_AVAIL` branch here
already exists to absorb. But `RemoveFromWaitQueue()` calls `CleanUpLock()`,
and that **deletes the proclock whenever it holds nothing else** — always the
case for a pure waiter, e.g. the `ShareLock` a `VirtualXactLock()` sleeps on.
The dynahash element goes back on the freelist, so `holdMask` afterwards reads
whatever the slot's next owner put there.

Zero, usually — and then the `NOT_AVAIL` branch does the right thing by
accident. A stray set bit, and we believe in a grant that never happened:
`GrantLockLocal()` runs, and the `LockRelease()` that follows ungrants counts
that were never incremented and removes a proclock that is no longer in the
table.

Why this statement: orioledb calls `oxid_notify_all()` from the
`INSERT ... ON CONFLICT DO UPDATE` retry loop (`o_tbl_insert_on_conflict()`),
which is also what makes the conflicting backends sleep in
`wait_for_oxid()` → `VirtualXactLock()` in the first place.

## Evidence

A probe comparing the captured pointer against a re-find, under contended
upserts against orioledb:

```
WARNING: stale proclock after wait: captured 0x1150b0510, refound 0x0, holdMask 0, mode 5
```

**313 reads of an already-freed proclock in two minutes.** Forcing the recycled
slot to carry the lockmode bit — which is what happens for real when another
backend takes the slot between the free and this read — turns the very first
one into:

```
TRAP: failed Assert("(lock->nRequested > 0) && (lock->requested[lockmode] > 0)"), lock.c:1767
  ExceptionalCondition / UnGrantLock / LockRelease / VirtualXactLock
  ... / table_tuple_insert_with_arbiter / ExecInsert / ExecModifyTable
```

i.e. the assert-build face of the reported PANIC, reached from the upsert
executor path named in the ticket. (Antithesis runs a non-cassert build, so it
goes on to `CleanUpLock()` → `hash_search(HASH_REMOVE)` of an absent entry →
`PANIC: proclock table corrupted`.)

## The fix

Re-find the lock and the proclock from the locktag under the partition lock,
and decide from that. The lock itself can be gone too — the same
`CleanUpLock()` drops it once `nRequested` reaches zero — so the lookup starts
from the tag rather than from the captured `LOCK` pointer.

## Validation

With this change the same workload takes the re-find path **163 times in 60
seconds** (each one a freed-pointer read avoided) and runs clean: no PANIC, no
assert. orioledb's regress (48) and isolation (34) suites pass against the
patched backend.

## Not done here

**PG16 and PG17 carry the same post-wait check and need the same fix** —
`patches16` and `patches17`, same function, same `!(proclock->holdMask & ...)`
test. I built and validated only 18; the other two deserve the same change
rather than a blind port.