### PR TITLE
PG17: re-find the proclock after waiting instead of trusting a stale pointer

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1112,11 +1112,55 @@ LockAcquireExtended(const LOCKTAG *locktag,
 		 */
 
 		/*
+		 * Whether the lock was granted has to be re-read from the lock table,
+		 * not from the proclock pointer we captured before going to sleep.  A
+		 * wake-up driven by RemoveFromWaitQueue() -- which is how orioledb's
+		 * oxid_notify_all() releases waiters, reporting PROC_WAIT_STATUS_OK
+		 * afterwards -- runs CleanUpLock(), and that frees the proclock
+		 * whenever it holds nothing else, which is always so for a pure
+		 * waiter.  Reading holdMask through the freed element yields whatever
+		 * the next owner of that dynahash slot has put there; a stray set bit
+		 * makes us believe in a grant that never happened, and the release
+		 * that follows underflows the request counts and removes a proclock
+		 * that is no longer in the table ("proclock table corrupted").
+		 *
+		 * The lock itself can be gone too -- CleanUpLock() drops it once
+		 * nRequested reaches zero -- so start from the locktag.  Unlike the
+		 * PG18 version of this fix, the partition lock is still held here:
+		 * ProcSleep() takes it at entry and holds it at exit.
+		 */
+		if (!dontWait)
+		{
+			PROCLOCKTAG proclocktag;
+
+			lock = (LOCK *) hash_search_with_hash_value(LockMethodLockHash,
+														locktag,
+														hashcode,
+														HASH_FIND,
+														NULL);
+			proclock = NULL;
+			if (lock != NULL)
+			{
+				proclocktag.myLock = lock;
+				proclocktag.myProc = MyProc;
+				proclock = (PROCLOCK *)
+					hash_search_with_hash_value(LockMethodProcLockHash,
+												&proclocktag,
+												ProcLockHashCode(&proclocktag,
+																 hashcode),
+												HASH_FIND,
+												NULL);
+			}
+		}
+
+		/*
 		 * Check the proclock entry status. If dontWait = true, this is an
 		 * expected case; otherwise, it will only happen if something in the
-		 * ipc communication doesn't work correctly.
+		 * ipc communication doesn't work correctly, or if we were released
+		 * from the queue by RemoveFromWaitQueue().
 		 */
-		if (!(proclock->holdMask & LOCKBIT_ON(lockmode)))
+		if (proclock == NULL ||
+			!(proclock->holdMask & LOCKBIT_ON(lockmode)))
 		{
 			int		i;
 
@@ -1163,11 +1207,15 @@ LockAcquireExtended(const LOCKTAG *locktag,
 			else
 			{
 				/*
-				 * We should have gotten the lock, but somehow that didn't
-				 * happen. If we get here, it's a bug.
+				 * We've been removed from the queue without obtaining the
+				 * lock; with the re-find above, the proclock may be gone
+				 * altogether.
 				 */
-				PROCLOCK_PRINT("LockAcquire: INCONSISTENT", proclock);
-				LOCK_PRINT("LockAcquire: INCONSISTENT", lock, lockmode);
+				if (proclock != NULL)
+				{
+					PROCLOCK_PRINT("LockAcquire: INCONSISTENT", proclock);
+					LOCK_PRINT("LockAcquire: INCONSISTENT", lock, lockmode);
+				}
 				LWLockRelease(partitionLock);
 				/*
 				 * We've been removed from the queue without obtaining a lock.
@@ -1192,6 +1240,10 @@ LockAcquireExtended(const LOCKTAG *locktag,
 				return LOCKACQUIRE_NOT_AVAIL;
 			}
 		}
+		/* Keep the local lock's cached pointers in step. */
+		locallock->lock = lock;
+		locallock->proclock = proclock;
+
 		PROCLOCK_PRINT("LockAcquire: granted", proclock);
 		LOCK_PRINT("LockAcquire: granted", lock, lockmode);
 	}


### PR DESCRIPTION
PG17 counterpart of 28592521ad7 on `patches18` (ORI-247, `PANIC: proclock table
corrupted`).

**A plain cherry-pick is wrong here**, for two reasons — both worth knowing
before reviewing:

### 1. The partition lock

On PG18 `LockAcquireExtended()` releases the partition lock before
`WaitOnLock()`, so that fix re-takes it around the lookup. On PG17
`ProcSleep()` still *"must be held at entry, and will be held at exit"* — it
re-acquires it `LW_EXCLUSIVE` immediately before returning. Taking it again
here would self-deadlock. So the lookup is a plain `hash_search_with_hash_value`
with no acquire.

### 2. The `dontWait` path

PG17 handles a failed conditional acquisition inside this same block, and that
path never slept: `ProcSleep()` with `dontWait` returns without ever releasing
the partition lock, so no one can have run `RemoveFromWaitQueue()` on us and the
captured pointers are still good. Worse, that path *needs* them — it deletes the
proclock and decrements `lock->nRequested` itself. The re-find is therefore done
only when we actually slept.

Also guarded the `INCONSISTENT` prints, which can now see a proclock that is
gone rather than merely one without our bit, and kept the local lock's cached
pointers in step on the granted path.

### Validation

Same method as the PG18 fix, on a PG17 build with orioledb: a probe reporting a
proclock that was freed while we slept fires **157 times in 60 seconds** of the
contended-upsert workload — 157 reads of freed shared memory that this change no
longer performs — with no panic and no assertion failure.

PG16 port follows separately; its block has no `dontWait` case, so it is
simpler.