### PR TITLE
PG16: re-find the proclock after waiting instead of trusting a stale pointer

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1160,16 +1160,62 @@ LockAcquireExtended(const LOCKTAG *locktag,
 		 */
 
 		/*
-		 * Check the proclock entry status, in case something in the ipc
-		 * communication doesn't work correctly.
+		 * Whether the lock was granted has to be re-read from the lock table,
+		 * not from the proclock pointer we captured before going to sleep.  A
+		 * wake-up driven by RemoveFromWaitQueue() -- which is how orioledb's
+		 * oxid_notify_all() releases waiters, reporting PROC_WAIT_STATUS_OK
+		 * afterwards -- runs CleanUpLock(), and that frees the proclock
+		 * whenever it holds nothing else, which is always so for a pure
+		 * waiter.  Reading holdMask through the freed element yields whatever
+		 * the next owner of that dynahash slot has put there; a stray set bit
+		 * makes us believe in a grant that never happened, and the release
+		 * that follows underflows the request counts and removes a proclock
+		 * that is no longer in the table ("proclock table corrupted").
+		 *
+		 * The lock itself can be gone too -- CleanUpLock() drops it once
+		 * nRequested reaches zero -- so start from the locktag.  Unlike the
+		 * PG18 version of this fix, the partition lock is still held here:
+		 * ProcSleep() takes it at entry and holds it at exit.
 		 */
-		if (!(proclock->holdMask & LOCKBIT_ON(lockmode)))
+		{
+			PROCLOCKTAG proclocktag;
+
+			lock = (LOCK *) hash_search_with_hash_value(LockMethodLockHash,
+														locktag,
+														hashcode,
+														HASH_FIND,
+														NULL);
+			proclock = NULL;
+			if (lock != NULL)
+			{
+				proclocktag.myLock = lock;
+				proclocktag.myProc = MyProc;
+				proclock = (PROCLOCK *)
+					hash_search_with_hash_value(LockMethodProcLockHash,
+												&proclocktag,
+												ProcLockHashCode(&proclocktag,
+																 hashcode),
+												HASH_FIND,
+												NULL);
+			}
+		}
+
+		/*
+		 * Check the proclock entry status, in case something in the ipc
+		 * communication doesn't work correctly, or we were released from the
+		 * queue by RemoveFromWaitQueue().
+		 */
+		if (proclock == NULL ||
+			!(proclock->holdMask & LOCKBIT_ON(lockmode)))
 		{
 			int		i;
 
 			AbortStrongLockAcquire();
-			PROCLOCK_PRINT("LockAcquire: INCONSISTENT", proclock);
-			LOCK_PRINT("LockAcquire: INCONSISTENT", lock, lockmode);
+			if (proclock != NULL)
+			{
+				PROCLOCK_PRINT("LockAcquire: INCONSISTENT", proclock);
+				LOCK_PRINT("LockAcquire: INCONSISTENT", lock, lockmode);
+			}
 			/* Should we retry ? */
 			LWLockRelease(partitionLock);
 			/*
@@ -1195,6 +1241,10 @@ LockAcquireExtended(const LOCKTAG *locktag,
 			return LOCKACQUIRE_NOT_AVAIL;
 
 		}
+		/* Keep the local lock's cached pointers in step. */
+		locallock->lock = lock;
+		locallock->proclock = proclock;
+
 		PROCLOCK_PRINT("LockAcquire: granted", proclock);
 		LOCK_PRINT("LockAcquire: granted", lock, lockmode);
 	}


### PR DESCRIPTION
PG16 counterpart of 28592521ad7 on `patches18` (ORI-247, `PANIC: proclock table
corrupted`). Companion to #84 (PG17).

**Why a cherry-pick does not apply.** On PG18 `LockAcquireExtended()` releases
the partition lock before `WaitOnLock()`, so that fix re-takes it around the
lookup. On PG16 `ProcSleep()` holds the partition lock at entry and re-acquires
it `LW_EXCLUSIVE` before returning, so it is held here — acquiring it again
would self-deadlock. The lookup is a plain `hash_search_with_hash_value`.

Unlike PG17 there is no `dontWait` case in this block (a conditional
acquisition returns earlier), so the re-find is unconditional — this port is
the simpler of the two.

Also guarded the `INCONSISTENT` prints, which can now see a proclock that is
gone rather than merely one without our bit, and kept the local lock's cached
pointers in step on the granted path.

### Validation

Built PG16 with orioledb and ran the same contended-upsert workload used for
the PG18 and PG17 fixes, with a probe reporting a proclock that was freed while
we slept: **161 hits in 60 seconds** — 161 reads of freed shared memory that
this change no longer performs — with no panic and no assertion failure.

For the record, the same measurement across the three branches: PG18 163,
PG17 157, PG16 161 hits per 60 s. The defect is equally live on all three.