### PR TITLE
Verify the grant before recording it in LockErrorCleanup()

### DIFF
--- a/src/backend/storage/lmgr/lock.c
+++ b/src/backend/storage/lmgr/lock.c
@@ -1969,6 +1969,46 @@ AbortStrongLockAcquire(void)
 }
 
 /*
+ * AwaitedLockIsGranted -- does the shared lock table show the lock we went to
+ *		sleep for as held by us?
+ *
+ * Only meaningful while awaitedLock is set, and the caller must hold that
+ * lock's partition lock.  The lock object itself can be gone -- CleanUpLock()
+ * drops it once nRequested reaches zero -- so the lookup starts from the tag.
+ */
+bool
+AwaitedLockIsGranted(void)
+{
+	LOCK	   *lock;
+	PROCLOCK   *proclock;
+	PROCLOCKTAG proclocktag;
+
+	Assert(awaitedLock != NULL);
+
+	lock = (LOCK *) hash_search_with_hash_value(LockMethodLockHash,
+												&awaitedLock->tag.lock,
+												awaitedLock->hashcode,
+												HASH_FIND,
+												NULL);
+	if (lock == NULL)
+		return false;
+
+	proclocktag.myLock = lock;
+	proclocktag.myProc = MyProc;
+	proclock = (PROCLOCK *)
+		hash_search_with_hash_value(LockMethodProcLockHash,
+									&proclocktag,
+									ProcLockHashCode(&proclocktag,
+													 awaitedLock->hashcode),
+									HASH_FIND,
+									NULL);
+	if (proclock == NULL)
+		return false;
+
+	return (proclock->holdMask & LOCKBIT_ON(awaitedLock->tag.mode)) != 0;
+}
+
+/*
  * GrantAwaitedLock -- call GrantLockLocal for the lock we are doing
  *		WaitOnLock on.
  *

--- a/src/backend/storage/lmgr/proc.c
+++ b/src/backend/storage/lmgr/proc.c
@@ -858,8 +858,19 @@ LockErrorCleanup(void)
 		 * granted us the lock, or perhaps they detected a deadlock. If they
 		 * did grant us the lock, we'd better remember it in our local lock
 		 * table.
+		 *
+		 * PROC_WAIT_STATUS_OK is not by itself proof of a grant.  orioledb
+		 * releases waiters from oxid_notify_all() with RemoveFromWaitQueue()
+		 * and reports OK afterwards, and RemoveFromWaitQueue() ->
+		 * CleanUpLock() has deleted our proclock by then -- always, for a
+		 * pure waiter such as the ShareLock a VirtualXactLock() sleeps on.
+		 * Recording a grant we never got would leave the local lock table
+		 * holding a freed proclock, and LockReleaseAll() would then OR a
+		 * releaseMask bit into whichever backend has since been handed that
+		 * dynahash slot.  So ask the lock table; we hold the partition lock.
 		 */
-		if (MyProc->waitStatus == PROC_WAIT_STATUS_OK)
+		if (MyProc->waitStatus == PROC_WAIT_STATUS_OK &&
+			AwaitedLockIsGranted())
 			GrantAwaitedLock();
 	}
 

--- a/src/include/storage/lock.h
+++ b/src/include/storage/lock.h
@@ -588,6 +588,7 @@ extern bool LockCheckConflicts(LockMethod lockMethodTable,
 							   LOCKMODE lockmode,
 							   LOCK *lock, PROCLOCK *proclock);
 extern void GrantLock(LOCK *lock, PROCLOCK *proclock, LOCKMODE lockmode);
+extern bool AwaitedLockIsGranted(void);
 extern void GrantAwaitedLock(void);
 extern LOCALLOCK *GetAwaitedLock(void);
 extern void ResetAwaitedLock(void);


### PR DESCRIPTION
A second consumer of the same lie that #83 removed from
`LockAcquireExtended()`.  Reported by Antithesis on a **PG17 build that
already carried** `1e13fa1993d`:

```
TRAP: failed Assert("(proclock->releaseMask & ~proclock->holdMask) == 0")
      lock.c, LockReleaseAll / ProcReleaseLocks
      / CommitTransactionCommand / InitPostgres
```

in a brand-new backend that had run nothing of its own.

## The chain

`oxid_notify_all()` releases a waiter with `RemoveFromWaitQueue()` and then
reports `PROC_WAIT_STATUS_OK`, without ever granting the lock.
`RemoveFromWaitQueue()` → `CleanUpLock()` has deleted that waiter's proclock by
then — always, for a pure waiter such as the ShareLock a `VirtualXactLock()`
sleeps on.

When the waiter simply wakes up, `LockAcquireExtended()` now re-reads the lock
table and undoes the local grant `ProcSleep()` made on its way out.  But when it
is unwinding on an error instead — a cancel, a deadlock elsewhere, any ERROR
raised while it waited — it never returns there.  `LockErrorCleanup()` runs
instead, and takes the status at face value:

```c
	if (MyProc->waitStatus == PROC_WAIT_STATUS_OK)
		GrantAwaitedLock();
```

So the local lock table claims a mode the shared table does not hold, with
`locallock->proclock` pointing at the freed proclock.  At transaction end — on
commit and on abort alike — the first pass of `LockReleaseAll()` does

```c
	if (locallock->nLocks > 0)
		locallock->proclock->releaseMask |= LOCKBIT_ON(locallock->tag.mode);
```

through that pointer, into whichever backend dynahash has since handed the slot
to.  That backend fails the assertion at its next commit; on an abort the masks
are forced instead, which is why the report is a *stranger* committing and not
the process that did the damage.

## Fix

Ask the lock table instead of believing the status.  The partition lock is held
at that point, so it is a plain lookup, and it starts from the tag because the
lock object can be gone too.

The code here is identical upstream text on all three patchsets, so the same
patch applies to each:

- `awaited-lock-verify-grant-18` (this PR) — full build, `make check` 231/231,
  `src/test/isolation` 121/121
- `awaited-lock-verify-grant-17` — cherry-picks clean, full build, `make check`
  225/225, `src/test/isolation` 120/120
- `awaited-lock-verify-grant-16` — cherry-picks clean, full build

(The isolation suites matter here: their deadlock tests are the ordinary way
through `LockErrorCleanup()`, where a real concurrent grant must still be
recorded.)

## Measured

PG17, contended orioledb upserts on 3 keys with savepoint rollbacks, statement
cancellations and connection churn, probes at both ends of the chain, five
minutes per run:

|                                                  | before | after |
|--------------------------------------------------|-------:|------:|
| the lie arrives at `LockErrorCleanup()`           |      3 |     4 |
| `releaseMask` written into a **foreign** proclock |      2 |     0 |

The lie itself is unchanged, as expected — what stops is believing it.  For
scale, the already-fixed path (`ProcSleep()`'s epilogue, undone afterwards by
#83) took the same lie 7487 times in those five minutes, so this is the rare
tail of a very common event, which fits a crash that showed up once in a
100-second Antithesis run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
